### PR TITLE
Allow to symbolicate 64-bit arch addresses

### DIFF
--- a/natos/NATOS.h
+++ b/natos/NATOS.h
@@ -15,9 +15,9 @@
 @property (nonatomic, copy, readwrite) NSString* XCArchivePath;
 @property (nonatomic, copy, readwrite) NSString* dSYMPath;      // if not present, derived from XCArchivePath
 @property (nonatomic, copy, readwrite) NSString* CPUArchitecture;
-@property (nonatomic, assign, readwrite) unsigned int mainFunctionStackAddress;
-@property (nonatomic, assign, readwrite) unsigned int loadAddress;
-@property (nonatomic, assign, readwrite) unsigned int targetStackAddress;
+@property (nonatomic, assign, readwrite) unsigned long long mainFunctionStackAddress;
+@property (nonatomic, assign, readwrite) unsigned long long loadAddress;
+@property (nonatomic, assign, readwrite) unsigned long long targetStackAddress;
 
 - (void) printUsage;
 

--- a/natos/NATOS.m
+++ b/natos/NATOS.m
@@ -22,9 +22,9 @@
 {
 }
 
-@property (nonatomic, assign, readwrite) unsigned int mainFunctionSymbolAddress;
-@property (nonatomic, assign, readwrite) unsigned int slide;
-@property (nonatomic, assign, readwrite) unsigned int targetSymbolAddress;
+@property (nonatomic, assign, readwrite) unsigned long long mainFunctionSymbolAddress;
+@property (nonatomic, assign, readwrite) unsigned long long slide;
+@property (nonatomic, assign, readwrite) unsigned long long targetSymbolAddress;
 
 - (BOOL) extractAndPrintSymbol;
 - (BOOL) deriveDSYMPath;
@@ -127,34 +127,34 @@
     
     if (self.mainFunctionStackAddress)
     {
-        printf("Main Stack Address == 0x%x\n", self.mainFunctionStackAddress);
+        printf("Main Stack Address == 0x%qx\n", self.mainFunctionStackAddress);
     }
     else if (self.loadAddress)
     {
-        printf("Load Address == 0x%x\n", self.loadAddress);
+        printf("Load Address == 0x%qx\n", self.loadAddress);
     }
-    printf("Target Stack Address == 0x%x\n", self.targetStackAddress);
+    printf("Target Stack Address == 0x%qx\n", self.targetStackAddress);
 
     if (self.slide || [self extractSlide])
     {
-        printf("Slide == 0x%x\n", self.slide);
+        printf("Slide == 0x%qx\n", self.slide);
         if (self.loadAddress || [self extractMainFunctionSymbolAddress])
         {
             if (self.mainFunctionSymbolAddress)
             {
-                printf("Main Symbol Address == 0x%x\n", self.mainFunctionSymbolAddress);
+                printf("Main Symbol Address == 0x%qx\n", self.mainFunctionSymbolAddress);
             }
 
             if (self.loadAddress || [self calculateLoadAddress])
             {
                 if (self.mainFunctionSymbolAddress)
                 {
-                    printf("Load Address == 0x%x\n", self.loadAddress);
+                    printf("Load Address == 0x%qx\n", self.loadAddress);
                 }
 
                 /*if*/ ([self calculateTargetSymbolAddress]);
                 {
-                    printf("Target Symbol Address == 0x%x\n", self.targetSymbolAddress);
+                    printf("Target Symbol Address == 0x%qx\n", self.targetSymbolAddress);
                     success = [self calculateTargetSymbol];
                 }
             }
@@ -224,7 +224,7 @@
 
 - (BOOL) extractSlide
 {
-    unsigned int slide = 0;
+    unsigned long long slide = 0;
     BOOL success = NO;
     
     @autoreleasepool {
@@ -304,7 +304,7 @@
 - (BOOL) calculateLoadAddress
 {
     BOOL success = NO;
-    unsigned int ld_address = self.mainFunctionStackAddress - self.mainFunctionSymbolAddress;
+    unsigned long long ld_address = self.mainFunctionStackAddress - self.mainFunctionSymbolAddress;
     if (ld_address > self.mainFunctionStackAddress)
     {
         fprintf(stderr, "main() stack address MUST be larger than the main() symbol address\n");
@@ -328,10 +328,10 @@
 - (BOOL) calculateTargetSymbolAddress
 {
     BOOL success = NO;
-    unsigned int func_symbol_address = self.targetStackAddress - self.loadAddress;
+    unsigned long long func_symbol_address = self.targetStackAddress - self.loadAddress;
     if (func_symbol_address > self.targetStackAddress)
     {
-        fprintf(stderr, "target stack address is too small for the calculated load address (0x%x)\n", self.loadAddress);
+        fprintf(stderr, "target stack address is too small for the calculated load address (0x%qx)\n", self.loadAddress);
     }
     else
     {
@@ -351,8 +351,8 @@
 
 - (BOOL) calculateTargetSymbol
 {
-    NSString* addy = [NSString stringWithFormat:@"0x%x", self.targetStackAddress];
-    NSString* addy2 = [NSString stringWithFormat:@"0x%x", (self.loadAddress ? self.loadAddress : self.slide)];
+    NSString* addy = [NSString stringWithFormat:@"0x%qx", self.targetStackAddress];
+    NSString* addy2 = [NSString stringWithFormat:@"0x%qx", (self.loadAddress ? self.loadAddress : self.slide)];
     NSString* output = [NSTask executeXcodeTool:@"atos" arguments:@[@"-arch", self.CPUArchitecture, @"-o", self.dSYMPath, (self.loadAddress ? @"-l" : @"-s"), addy2, addy]];
     NSArray* comp = [output componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
     output = comp.count > 0 ? [comp lastObject] : nil;

--- a/natos/NATOS.m
+++ b/natos/NATOS.m
@@ -261,14 +261,14 @@
 
 - (BOOL) extractMainFunctionSymbolAddress
 {
-    unsigned int main_symbol = 0;
+    unsigned long long main_symbol = 0;
     BOOL success = NO;
     
     @autoreleasepool {
         NSString* dwarfdump = [NSTask executeAndReturnStdOut:@"/usr/bin/xcrun" arguments:@[@"-find", @"-sdk", @"iphoneos", @"dwarfdump"]];
         NSString* output = [NSTask executeAndReturnStdOut:dwarfdump
                                                 arguments:@[@"--all", @"--arch", self.CPUArchitecture, self.dSYMPath]
-                                      withMaxStringLength:1024*100];
+                                      withMaxStringLength:1024*200];
         NSArray* lines = [output componentsSeparatedByString:@"\n"];
         for (NSString* line in lines)
         {

--- a/natos/NATOS.m
+++ b/natos/NATOS.m
@@ -234,7 +234,7 @@
         for (NSUInteger i = 0; i < lines.count && !success; i++)
         {
             NSString* line = [[lines objectAtIndex:i] stringByTrimmingCharactersInSet:whitespace];
-            if ([line isEqualToString:@"cmd LC_SEGMENT"])
+            if ([line isEqualToString:@"cmd LC_SEGMENT"] || [line isEqualToString:@"cmd LC_SEGMENT_64"])
             {
                 BOOL isText = NO;
                 for (NSUInteger j = 1; j+i < lines.count && j < 8 && !success; j++)

--- a/natos/NSString+Hex.h
+++ b/natos/NSString+Hex.h
@@ -9,5 +9,5 @@
 #import <Foundation/Foundation.h>
 
 @interface NSString (Hex)
-- (unsigned int) hexValue;
+- (unsigned long long) hexValue;
 @end

--- a/natos/NSString+Hex.m
+++ b/natos/NSString+Hex.m
@@ -9,11 +9,11 @@
 #import "NSString+Hex.h"
 
 @implementation NSString (Hex)
-- (unsigned int) hexValue
+- (unsigned long long) hexValue
 {
-    unsigned int value   = 0;
+    unsigned long long value   = 0;
     NSScanner*   scanner = [NSScanner scannerWithString:self];
-    [scanner scanHexInt:&value];
+    [scanner scanHexLongLong:&value];
     return value;
 }
 @end


### PR DESCRIPTION
First of all thank you for making this project public.

There are several fixes in PR:
- make properties and vars 64-bit supported
- otool provides LC_SEGMENT_64 output, so we need to catch it correctly
- increase max line size for dwarfdump output :) 
